### PR TITLE
added possibility to define _parent field

### DIFF
--- a/bin/elasticsearch-reindex.js
+++ b/bin/elasticsearch-reindex.js
@@ -170,7 +170,8 @@ if (cluster.isMaster) {
       client      : to_client,
       indexer     : custom_indexer ? custom_indexer.index : null,
       index       : to_path.index,
-      type        : to_path.type
+      type        : to_path.type,
+      parent      : cli.parent
     }, function(err) {
       if (err) {
         logger.fatal(err);

--- a/bin/elasticsearch-reindex.js
+++ b/bin/elasticsearch-reindex.js
@@ -26,6 +26,7 @@ cli
 .option('-r, --trace', 'default false', false)
 .option('-n, --max_docs [value]', 'default -1 unlimited', -1)
 .option('-v, --api_ver [value]', 'default 1.5', '1.5')
+.option('-p, --parent [value]', 'if set, uses this field as parent field', '')
 .parse(process.argv);
 
 var logger        = bunyan.createLogger({

--- a/lib/indexer.js
+++ b/lib/indexer.js
@@ -20,11 +20,17 @@ Indexer.prototype.index = function(docs, options, cb) {
     bulk:100,
   };
   options.indexer = options.indexer || function(item, options) {
+    var index = {index:{_index:options.index || item._index, _type:options.type || item._type, _id: item._id}};
+    if(options.parent != '') {
+      index.index._parent = item._source[options.parent];
+    }
+
     return [
-      {index:{_index:options.index || item._index, _type:options.type || item._type, _id: item._id}},
+      index,
       item._source
     ];
   };
+
   var chunks = _.toArray(_.groupBy(docs, function(item, index){ return Math.floor(index/options.bulk); }));
   async.eachLimit(chunks, options.concurrency, function(chunk, cb) {
     var bulk_data = [];


### PR DESCRIPTION
This adds the possibility to define a parent field if the mapping is used in a child/parent relation.

Can be used as follows:

        elasticsearch-reindex -f http://localhost:9200/old/mapping -t http://localhost:9200/new/mapping -p ParentField

This will use the field ParentField of the old mapping as the _parent value for the new mapping.