### PR TITLE
Support for Basic Auth

### DIFF
--- a/bin/elasticsearch-reindex.js
+++ b/bin/elasticsearch-reindex.js
@@ -93,7 +93,7 @@ if (cluster.isMaster) {
       logger.fatal("worker exited with error code: "+code);
       console.log("worker exited with error code: "+code);
     } else {
-      console.log('    Worker finished his work!');
+      console.log('    Worker finished its work!');
     }
   });
 } else {

--- a/bin/elasticsearch-reindex.js
+++ b/bin/elasticsearch-reindex.js
@@ -10,6 +10,7 @@ var cli           = require('commander'),
     ProgressBar   = require('progress'),
     fs            = require('fs'),
     Indexer       = require('../lib/indexer'),
+    escapeRegExp  = require('../lib/escape-regexp'),
     URI           = require('URIjs');
 
 
@@ -37,7 +38,6 @@ var logger        = bunyan.createLogger({
     path: cli.log_path
   }]
 });
-
 
 var custom_indexer = cli.args[0] ? require(fs.realpathSync(cli.args[0])) : null;
 
@@ -108,8 +108,8 @@ if (cluster.isMaster) {
 
   var from_uri      = new URI(cli.from),
       to_uri        = new URI(cli.to),
-      from_client   = new elasticsearch.Client({host:cli.from.replace(from_uri.path(), ''), requestTimeout:cli.request_timeout, apiVersion: cli.api_ver }),
-      to_client     = new elasticsearch.Client({host:cli.to.replace(to_uri.path(), ''), requestTimeout:cli.request_timeout, apiVersion: cli.api_ver }),
+      from_client   = new elasticsearch.Client({ host: cli.from.replace(new RegExp(escapeRegExp(from_uri.path()) + '.*'), ''), requestTimeout: cli.request_timeout, apiVersion: cli.api_ver }),
+      to_client     = new elasticsearch.Client({ host: cli.to.replace(new RegExp(escapeRegExp(to_uri.path()) + '.*'), ''), requestTimeout: cli.request_timeout, apiVersion: cli.api_ver }),
       from_path     = (function() { var tmp = from_uri.path().split('/'); return { index:tmp[1], type:tmp[2]}; })(),
       to_path       = (function() { var tmp = to_uri.path().split('/'); return { index:tmp[1], type:tmp[2]}; })(),
       processed_total        = 0,

--- a/lib/escape-regexp.js
+++ b/lib/escape-regexp.js
@@ -1,0 +1,4 @@
+module.exports = function escapeRegExp (reStr) {
+  'use strict';
+  return reStr.toString().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+};

--- a/lib/indexer.js
+++ b/lib/indexer.js
@@ -1,3 +1,5 @@
+/* jshint expr:true */
+
 var async         = require('async'),
     _             = require('underscore'),
     EventEmitter  = require('events').EventEmitter,
@@ -6,11 +8,11 @@ var async         = require('async'),
 
 function Indexer () {
   EventEmitter.call(this);
-};
+}
 
 var _defaultIndexer = function(item, options) {
   var index = {index:{_index:options.index || item._index, _type:options.type || item._type, _id: item._id}};
-  if(options.parent != '') {
+  if(options.parent !== '') {
     index.index._parent = item._source[options.parent];
   }
 
@@ -128,7 +130,7 @@ Indexer.prototype.indexPromise = function(docs, options, cb) {
       });
 
       cb(sent = err);
-    })
+    });
   }, function(err) {
     cb(err);
   });


### PR DESCRIPTION
Grabbing `URI#host()` from the supplied connection strings stripped out things like protocol and basic auth, making it impossible to connect to an authenticated cluster. This PR gets the connection URL by lopping off the path rather than grabbing only the host, along with a little cleanup for the linter.