### PR TITLE
Use agentkeepalive to avoid no more living connections error

### DIFF
--- a/bin/elasticsearch-reindex.js
+++ b/bin/elasticsearch-reindex.js
@@ -2,6 +2,7 @@
 
 var cli           = require('commander'),
     elasticsearch = require('elasticsearch'),
+    AgentKeepAlive = require('agentkeepalive'),
     cluster       = require('cluster'),
     moment        = require('moment'),
     _             = require('underscore'),
@@ -190,7 +191,17 @@ if (cluster.isMaster) {
 
     config.host = res.host = tokens.join('/');
 
-    res.client = new elasticsearch.Client(config);
+    res.client = new elasticsearch.Client({
+        hosts: [tokens[2]],
+        maxRetries: 10,
+        keepAlive: true,
+        maxSockets: 10,
+        minSockets: 10,
+        createNodeAgent: function (connection, config) {
+          return new AgentKeepAlive(connection.makeAgentConfig(config));
+        }
+      }
+    );
     return res;
   }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/garbin/elasticsearch-reindex",
   "dependencies": {
+    "agentkeepalive": "^3.0.0",
     "async": "^1.5.0",
     "bluebird": "^3.3.4",
     "bunyan": "^1.2.0",


### PR DESCRIPTION
Related to this problem https://github.com/elastic/elasticsearch-js/issues/196 I found this fix to avoid the 'no more living connections error'.
