### PR TITLE
Enable ES 5.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bluebird": "^3.3.4",
     "bunyan": "^1.2.0",
     "commander": "^2.4.0",
-    "elasticsearch": "^11.0.0",
+    "elasticsearch": "^13.0.0",
     "event-emitter": "^0.3.1",
     "http-aws-es": "^1.1.3",
     "moment": "^2.8.3",


### PR DESCRIPTION
- Bump client lib version to 0.13.x
- Use search with doc sort to initialise scroll
  where possible per deprecation of scan in 2.x
  and removal in 5.x

Fixes https://github.com/garbin/elasticsearch-reindex/issues/30

Note that a different set of valid version strings are supported by the new [client lib](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html)· I have left the default version at 1.7 (the only 1.x version with an `apiVersion` string), but really this should be bumped, if for no other reason than that Elastic no longer support versions pre-2.x.